### PR TITLE
feat: modernize ui with signals and lazy pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.angular/

--- a/angular.json
+++ b/angular.json
@@ -26,7 +26,7 @@
             }
           },
           "options": {
-            "assets": [],
+            "assets": ["src/assets"],
             "index": "src/index.html",
             "browser": "src/main.ts",
             "outputPath": "dist/demo",

--- a/docs/improvement-plan.md
+++ b/docs/improvement-plan.md
@@ -1,0 +1,32 @@
+# Plan d'amélioration de l'application
+
+Cette feuille de route regroupe les optimisations prioritaires pour moderniser l'application Angular et améliorer l'expérience utilisateur.
+
+## Architecture et structure
+- **Basculer tous les composants vers les dernières conventions Angular** : supprimer les déclarations `standalone: true` superflues et migrer les importations vers le champ `imports` tout en conservant l'approche standalone. 【F:src/app/components/header/header.component.ts†L1-L37】【F:src/app/components/footer/footer.component.ts†L1-L37】【F:src/app/pages/home/home.component.ts†L1-L34】【F:src/app/components/layout/layout.component.ts†L1-L25】
+- **Remplacer l'usage de `HostListener` par la configuration `host` du décorateur** afin de respecter les bonnes pratiques et centraliser les bindings dans la métadonnée du composant. 【F:src/app/components/header/header.component.ts†L1-L33】
+- **Introduire des signaux pour l'état local** (`isScrolled`, `isMenuOpen`, `features`, `socialLinks`) et dériver les valeurs calculées avec `computed()` afin de tirer parti de la réactivité fine d'Angular 17+. 【F:src/app/components/header/header.component.ts†L14-L35】【F:src/app/pages/home/home.component.ts†L12-L33】【F:src/app/components/footer/footer.component.ts†L12-L37】
+- **Isoler la configuration des données statiques** (navigation, réseaux sociaux, fonctionnalités) dans des fichiers de type `data.ts` afin de faciliter la maintenance et d'encourager la réutilisation. 【F:src/app/components/header/header.component.ts†L17-L23】【F:src/app/components/footer/footer.component.ts†L16-L37】【F:src/app/pages/home/home.component.ts†L12-L33】
+
+## Templates et accessibilité
+- **Adopter le nouveau contrôle de flux** (`@for`, `@if`) et supprimer `*ngFor` pour bénéficier d'un rendu plus performant et de meilleures options de suivi. 【F:src/app/pages/home/home.component.html†L1-L45】【F:src/app/components/header/header.component.html†L10-L34】【F:src/app/components/footer/footer.component.html†L15-L35】
+- **Renforcer l'accessibilité du header** : ajouter des attributs `aria-expanded`, `aria-controls` et gérer le focus lorsque le menu mobile s'ouvre. 【F:src/app/components/header/header.component.html†L1-L35】
+- **Harmoniser la navigation du footer** en utilisant `routerLink` plutôt que des liens absolus pour bénéficier du routage Angular et éviter le rechargement complet de la page. 【F:src/app/components/footer/footer.component.html†L15-L20】
+- **Mettre en place `NgOptimizedImage`** pour remplacer la zone placeholder et préparer l'intégration d'une véritable photo ou illustration optimisée. 【F:src/app/pages/home/home.component.html†L1-L30】
+
+## Style et performances
+- **Consolider les styles globaux** en factorisant les variables SCSS et en introduisant un thème clair/sombre contrôlé par signaux pour améliorer l'expérience utilisateur. 【F:src/global_styles.scss†L1-L101】
+- **Ajouter des styles responsives dédiés** pour les composants Header, Home et Footer afin d'assurer une expérience mobile fluide (actuellement, la plupart des règles sont globales). 【F:src/app/components/header/header.component.scss†L1-L157】【F:src/app/pages/home/home.component.scss†L1-L161】【F:src/app/components/footer/footer.component.scss†L1-L116】
+- **Optimiser la gestion du scroll** du header (debounce, seuil configurable) pour éviter les recalculs inutiles lors de défilements rapides. 【F:src/app/components/header/header.component.ts†L24-L27】
+
+## Contenu et SEO
+- **Enrichir les métadonnées de la page d'accueil** (balises title, description, Open Graph) directement dans `index.html` ou via un service dédié. 【F:src/index.html†L1-L23】
+- **Compléter les sections de contenu** (Portfolio, Blog, Contact) avec des routes lazy-loaded et des composants dédiés pour offrir une navigation complète. 【F:src/app/components/header/header.component.ts†L17-L23】【F:src/app/components/footer/footer.component.html†L15-L34】
+- **Ajouter un composant "Call To Action" réutilisable** pour inciter au contact et améliorer le taux de conversion.
+
+## Qualité du code et outillage
+- **Mettre en place des tests unitaires ciblant les composants clés** (Header, Home, Footer) afin de garantir la stabilité du rendu et des interactions.
+- **Configurer ESLint et Prettier** pour uniformiser le formatage et prévenir les régressions de style.
+- **Ajouter un pipeline CI simple** (GitHub Actions) exécutant lint, tests et build afin d'automatiser les vérifications de qualité.
+
+Ces améliorations permettront de hisser l'application au niveau des standards modernes d'Angular tout en offrant une expérience utilisateur plus riche et performante.

--- a/src/app/components/call-to-action/call-to-action.component.html
+++ b/src/app/components/call-to-action/call-to-action.component.html
@@ -1,0 +1,14 @@
+<section class="cta" [class.cta--emphasize]="emphasize()">
+  <div class="cta-content">
+    <h3 class="cta-title">{{ title() }}</h3>
+    @if (description()) {
+      <p class="cta-description">{{ description() }}</p>
+    }
+  </div>
+  <div class="cta-actions">
+    <a [routerLink]="primaryLink()" class="btn btn-primary">{{ primaryLabel() }}</a>
+    @if (hasSecondaryAction()) {
+      <a [routerLink]="secondaryLink()!" class="btn btn-outline">{{ secondaryLabel() }}</a>
+    }
+  </div>
+</section>

--- a/src/app/components/call-to-action/call-to-action.component.scss
+++ b/src/app/components/call-to-action/call-to-action.component.scss
@@ -1,0 +1,67 @@
+.cta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 2.5rem;
+  border-radius: 1.5rem;
+  border: 1px solid var(--border-color);
+  background: var(--surface-color);
+  box-shadow: var(--shadow-soft);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow);
+  }
+}
+
+.cta--emphasize {
+  background: linear-gradient(135deg, var(--primary-color), #7c3aed);
+  color: #fff;
+
+  .cta-title,
+  .cta-description {
+    color: inherit;
+  }
+
+  .btn-outline {
+    border-color: #fff;
+    color: #fff;
+
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.15);
+    }
+  }
+}
+
+.cta-title {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  color: var(--text-color);
+}
+
+.cta-description {
+  color: var(--secondary-color);
+  font-size: 1.05rem;
+  margin: 0;
+}
+
+.cta-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 768px) {
+  .cta {
+    flex-direction: column;
+    text-align: center;
+    padding: 2rem;
+  }
+
+  .cta-actions {
+    justify-content: center;
+  }
+}

--- a/src/app/components/call-to-action/call-to-action.component.ts
+++ b/src/app/components/call-to-action/call-to-action.component.ts
@@ -1,0 +1,24 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-call-to-action',
+  imports: [CommonModule, RouterModule],
+  templateUrl: './call-to-action.component.html',
+  styleUrls: ['./call-to-action.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class CallToActionComponent {
+  readonly title = input.required<string>();
+  readonly description = input<string>('');
+  readonly primaryLabel = input.required<string>();
+  readonly primaryLink = input.required<string>();
+  readonly secondaryLabel = input<string | undefined>();
+  readonly secondaryLink = input<string | undefined>();
+  readonly emphasize = input<boolean>(false);
+
+  protected readonly hasSecondaryAction = computed(
+    () => !!this.secondaryLabel() && !!this.secondaryLink()
+  );
+}

--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -1,4 +1,4 @@
-<footer class="footer">
+<footer class="footer" role="contentinfo">
   <div class="container">
     <div class="footer-content">
       <div class="footer-section">
@@ -12,29 +12,40 @@
       <div class="footer-section">
         <h4 class="section-title">Navigation</h4>
         <ul class="footer-links">
-          <li><a href="/" class="footer-link">Accueil</a></li>
-          <li><a href="/about" class="footer-link">À propos</a></li>
-          <li><a href="/portfolio" class="footer-link">Portfolio</a></li>
-          <li><a href="/blog" class="footer-link">Blog</a></li>
-          <li><a href="/contact" class="footer-link">Contact</a></li>
+          @for (item of navigationItems(); track item.path) {
+            <li>
+              <a
+                [routerLink]="item.path"
+                class="footer-link"
+                routerLinkActive="active"
+                [routerLinkActiveOptions]="{ exact: item.path === '/' }"
+              >
+                {{ item.label }}
+              </a>
+            </li>
+          }
         </ul>
       </div>
 
-      <div class="footer-section">
-        <h4 class="section-title">Réseaux sociaux</h4>
-        <div class="social-links">
-          <a
-            *ngFor="let social of socialLinks"
-            [href]="social.url"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="social-link"
-            [title]="social.platform"
-          >
-            <span>{{ social.icon }}</span>
-          </a>
+      @if (hasSocialLinks()) {
+        <div class="footer-section">
+          <h4 class="section-title">Réseaux sociaux</h4>
+          <div class="social-links">
+            @for (social of socialLinks(); track social.platform) {
+              <a
+                [href]="social.url"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="social-link"
+                [title]="social.platform"
+              >
+                <span aria-hidden="true">{{ social.icon }}</span>
+                <span class="sr-only">{{ social.platform }}</span>
+              </a>
+            }
+          </div>
         </div>
-      </div>
+      }
     </div>
 
     <div class="footer-bottom">

--- a/src/app/components/footer/footer.component.scss
+++ b/src/app/components/footer/footer.component.scss
@@ -1,90 +1,86 @@
-// Variables locales
-$footer-bg: #1e293b;
-$footer-text: #e2e8f0;
-$footer-text-muted: #94a3b8;
-$footer-border: #334155;
-
 .footer {
-  background-color: $footer-bg;
-  color: $footer-text;
+  background: color-mix(in srgb, var(--background-color) 92%, #0f172a 8%);
+  color: var(--text-color);
   padding: 3rem 0 1rem;
   margin-top: auto;
 }
 
 .footer-content {
   display: grid;
-  grid-template-columns: 2fr 1fr 1fr;
-  gap: 2rem;
-  margin-bottom: 2rem;
+  grid-template-columns: minmax(0, 2fr) repeat(2, minmax(0, 1fr));
+  gap: clamp(1.5rem, 2vw, 3rem);
+  margin-bottom: 2.5rem;
 }
 
 .footer-section {
   display: flex;
   flex-direction: column;
+  gap: 0.75rem;
 }
 
 .footer-title {
   font-size: 1.5rem;
   font-weight: 700;
-  margin-bottom: 1rem;
-  background: linear-gradient(135deg, #60a5fa, #a78bfa);
+  margin-bottom: 0.75rem;
+  background: linear-gradient(135deg, var(--primary-color), #a78bfa);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
 }
 
 .footer-description {
-  color: $footer-text-muted;
+  color: color-mix(in srgb, var(--secondary-color) 80%, var(--text-color) 20%);
   line-height: 1.6;
+  max-width: 28rem;
 }
 
 .section-title {
   font-size: 1.1rem;
   font-weight: 600;
-  margin-bottom: 1rem;
-  color: $footer-text;
+  margin-bottom: 0.5rem;
+  color: var(--text-color);
 }
 
 .footer-links {
   list-style: none;
   padding: 0;
   margin: 0;
-  
-  li {
-    margin-bottom: 0.5rem;
-  }
+  display: grid;
+  gap: 0.5rem;
 }
 
 .footer-link {
-  color: $footer-text-muted;
+  color: color-mix(in srgb, var(--secondary-color) 80%, var(--text-color) 20%);
   text-decoration: none;
   transition: color 0.2s ease;
-  
-  &:hover {
-    color: #60a5fa;
+
+  &:hover,
+  &.active {
+    color: var(--primary-color);
   }
 }
 
 .social-links {
   display: flex;
   gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .social-link {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 40px;
   height: 40px;
-  background-color: $footer-border;
+  background-color: color-mix(in srgb, var(--surface-color) 40%, #1e293b 60%);
   border-radius: 50%;
   text-decoration: none;
   font-size: 1.2rem;
-  transition: all 0.2s ease;
-  
+  transition: transform 0.2s ease, background-color 0.2s ease;
+
   &:hover {
-    background-color: #475569;
     transform: translateY(-2px);
+    background-color: color-mix(in srgb, var(--primary-color) 65%, var(--surface-color) 35%);
   }
 }
 
@@ -93,21 +89,19 @@ $footer-border: #334155;
   justify-content: space-between;
   align-items: center;
   padding-top: 2rem;
-  border-top: 1px solid $footer-border;
-  font-size: 0.9rem;
-  color: $footer-text-muted;
+  border-top: 1px solid color-mix(in srgb, var(--border-color) 60%, transparent);
+  font-size: 0.95rem;
+  color: color-mix(in srgb, var(--secondary-color) 70%, var(--text-color) 30%);
+  gap: 1rem;
 }
 
-/* Responsive */
 @media (max-width: 768px) {
   .footer-content {
     grid-template-columns: 1fr;
-    gap: 1.5rem;
   }
 
   .footer-bottom {
     flex-direction: column;
-    gap: 1rem;
     text-align: center;
   }
 

--- a/src/app/components/footer/footer.component.ts
+++ b/src/app/components/footer/footer.component.ts
@@ -1,38 +1,19 @@
-import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { SocialLink } from '../../types/common.types';
+import { ChangeDetectionStrategy, Component, computed, signal } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { SOCIAL_LINKS } from '../../data/social-links.data';
+import { NAVIGATION_ITEMS } from '../../data/navigation.data';
 
 @Component({
   selector: 'app-footer',
-  standalone: true,
-  imports: [CommonModule],
+  imports: [RouterModule],
   templateUrl: './footer.component.html',
-  styleUrls: ['./footer.component.scss']
+  styleUrls: ['./footer.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FooterComponent {
-  currentYear = new Date().getFullYear();
-  angularVersion = '20';
-
-  socialLinks: SocialLink[] = [
-    {
-      platform: 'GitHub',
-      url: 'https://github.com/thierno-bah',
-      icon: '🐙'
-    },
-    {
-      platform: 'LinkedIn',
-      url: 'https://linkedin.com/in/thierno-bah',
-      icon: '💼'
-    },
-    {
-      platform: 'Twitter',
-      url: 'https://twitter.com/thierno_bah',
-      icon: '🐦'
-    },
-    {
-      platform: 'Email',
-      url: 'mailto:contact@thierno-bah.fr',
-      icon: '📧'
-    }
-  ];
+  protected readonly currentYear = new Date().getFullYear();
+  protected readonly angularVersion = '20';
+  protected readonly navigationItems = signal(NAVIGATION_ITEMS);
+  protected readonly socialLinks = signal(SOCIAL_LINKS);
+  protected readonly hasSocialLinks = computed(() => this.socialLinks().length > 0);
 }

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -1,36 +1,56 @@
-<header class="header" [class.scrolled]="isScrolled">
-  <nav class="nav container">
-    <div class="nav-brand">
-      <a routerLink="/" class="brand-link">
-        <span class="brand-text">Thierno Bah</span>
-      </a>
-    </div>
+<nav class="nav container" role="navigation" aria-label="Navigation principale">
+  <div class="nav-brand">
+    <a routerLink="/" class="brand-link" aria-label="Retour à l'accueil">
+      <span class="brand-text">Thierno Bah</span>
+    </a>
+  </div>
 
-    <div class="nav-menu" [class.active]="isMenuOpen">
-      <ul class="nav-list">
-        <li *ngFor="let item of navigationItems" class="nav-item">
+  <div
+    class="nav-menu"
+    [class.active]="isMenuOpen()"
+    id="primary-navigation"
+    [attr.aria-hidden]="!isMenuOpen()"
+  >
+    <ul class="nav-list">
+      @for (item of navigationItems(); track item.path) {
+        <li class="nav-item">
           <a
             [routerLink]="item.path"
             class="nav-link"
             routerLinkActive="active"
             [routerLinkActiveOptions]="{ exact: item.path === '/' }"
             (click)="closeMenu()"
+            #navLink
           >
             {{ item.label }}
           </a>
         </li>
-      </ul>
-    </div>
+      }
+    </ul>
+  </div>
+
+  <div class="nav-actions">
+    <button
+      type="button"
+      class="theme-toggle"
+      (click)="toggleTheme()"
+      [attr.aria-label]="themeLabel()"
+    >
+      <span aria-hidden="true">{{ themeIcon() }}</span>
+    </button>
 
     <button
+      type="button"
       class="menu-toggle"
-      [class.active]="isMenuOpen"
+      [class.active]="isMenuOpen()"
       (click)="toggleMenu()"
-      aria-label="Toggle navigation"
+      [attr.aria-label]="menuButtonLabel()"
+      [attr.aria-expanded]="isMenuOpen()"
+      aria-controls="primary-navigation"
     >
       <span></span>
       <span></span>
       <span></span>
     </button>
-  </nav>
-</header>
+  </div>
+</nav>

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -1,22 +1,20 @@
-// Variables locales
-$header-height: 70px;
-
-.header {
+:host {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
-  background-color: rgba(255, 255, 255, 0.95);
+  display: block;
+  background-color: color-mix(in srgb, var(--background-color) 92%, transparent);
   backdrop-filter: blur(10px);
   border-bottom: 1px solid transparent;
-  transition: all 0.3s ease;
+  transition: background-color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
   z-index: 1000;
-  
-  &.scrolled {
-    background-color: rgba(255, 255, 255, 0.98);
-    border-bottom-color: var(--border-color);
-    box-shadow: var(--shadow);
-  }
+}
+
+:host(.scrolled) {
+  background-color: color-mix(in srgb, var(--background-color) 98%, transparent);
+  border-bottom-color: var(--border-color);
+  box-shadow: var(--shadow);
 }
 
 .nav {
@@ -24,14 +22,12 @@ $header-height: 70px;
   justify-content: space-between;
   align-items: center;
   padding: 1rem 0;
-  height: $header-height;
+  min-height: 70px;
 }
 
-.nav-brand {
-  .brand-link {
-    text-decoration: none;
-    color: var(--text-color);
-  }
+.nav-brand .brand-link {
+  text-decoration: none;
+  color: var(--text-color);
 }
 
 .brand-text {
@@ -41,6 +37,11 @@ $header-height: 70px;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
+}
+
+.nav-menu {
+  display: flex;
+  align-items: center;
 }
 
 .nav-list {
@@ -57,12 +58,12 @@ $header-height: 70px;
   font-weight: 500;
   transition: color 0.2s ease;
   position: relative;
-  
+
   &:hover,
   &.active {
     color: var(--primary-color);
   }
-  
+
   &::after {
     content: '';
     position: absolute;
@@ -73,10 +74,35 @@ $header-height: 70px;
     background-color: var(--primary-color);
     transition: width 0.3s ease;
   }
-  
+
   &:hover::after,
   &.active::after {
     width: 100%;
+  }
+}
+
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-color);
+  cursor: pointer;
+  transition: transform 0.2s ease, background-color 0.2s ease;
+
+  &:hover {
+    transform: translateY(-1px);
+    background-color: var(--surface-hover);
   }
 }
 
@@ -87,7 +113,7 @@ $header-height: 70px;
   border: none;
   cursor: pointer;
   padding: 0.5rem;
-  
+
   span {
     width: 25px;
     height: 3px;
@@ -95,53 +121,57 @@ $header-height: 70px;
     margin: 3px 0;
     transition: 0.3s;
   }
-  
+
   &.active {
     span:nth-child(1) {
       transform: rotate(-45deg) translate(-5px, 6px);
     }
-    
+
     span:nth-child(2) {
       opacity: 0;
     }
-    
+
     span:nth-child(3) {
       transform: rotate(45deg) translate(-5px, -6px);
     }
   }
 }
 
-/* Responsive */
+@media (max-width: 992px) {
+  .nav-list {
+    gap: 1.5rem;
+  }
+}
+
 @media (max-width: 768px) {
   .nav-menu {
     position: absolute;
     top: 100%;
     left: 0;
     right: 0;
-    background-color: white;
+    background-color: var(--surface-color);
     border-top: 1px solid var(--border-color);
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     transform: translateY(-100%);
     opacity: 0;
     visibility: hidden;
-    transition: all 0.3s ease;
-    
-    &.active {
-      transform: translateY(0);
-      opacity: 1;
-      visibility: visible;
-    }
+    transition: transform 0.3s ease, opacity 0.3s ease;
+  }
+
+  .nav-menu.active {
+    transform: translateY(0);
+    opacity: 1;
+    visibility: visible;
   }
 
   .nav-list {
     flex-direction: column;
-    gap: 0;
-    padding: 1rem 0;
+    width: 100%;
   }
 
   .nav-item {
     border-bottom: 1px solid var(--border-color);
-    
+
     &:last-child {
       border-bottom: none;
     }

--- a/src/app/components/layout/layout.component.ts
+++ b/src/app/components/layout/layout.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterOutlet } from '@angular/router';
 import { HeaderComponent } from '../header/header.component';
@@ -6,20 +6,21 @@ import { FooterComponent } from '../footer/footer.component';
 
 @Component({
   selector: 'app-layout',
-  standalone: true,
   imports: [CommonModule, RouterOutlet, HeaderComponent, FooterComponent],
   templateUrl: './layout.component.html',
   styles: [`
-    .app-layout {
+    :host {
       min-height: 100vh;
       display: flex;
       flex-direction: column;
+      background: var(--background-color);
     }
 
     .main-content {
       flex: 1;
-      padding-top: 70px; /* Hauteur du header fixe */
+      padding-top: 70px;
     }
-  `]
+  `],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class LayoutComponent {}

--- a/src/app/data/features.data.ts
+++ b/src/app/data/features.data.ts
@@ -1,0 +1,24 @@
+import { Feature } from '../types/common.types';
+
+export const FEATURES: ReadonlyArray<Feature> = [
+  {
+    icon: '🎨',
+    title: 'Frontend Development',
+    description: "Création d'interfaces utilisateur modernes avec React, Angular et Vue.js"
+  },
+  {
+    icon: '⚙️',
+    title: 'Backend Development',
+    description: 'APIs robustes avec Node.js, Python et bases de données relationnelles/NoSQL'
+  },
+  {
+    icon: '🚀',
+    title: 'DevOps & Cloud',
+    description: 'Déploiement et infrastructure cloud avec AWS, Docker et CI/CD'
+  },
+  {
+    icon: '📱',
+    title: 'Mobile Development',
+    description: 'Applications mobiles cross-platform avec React Native et Flutter'
+  }
+] as const;

--- a/src/app/data/navigation.data.ts
+++ b/src/app/data/navigation.data.ts
@@ -1,0 +1,9 @@
+import { NavigationItem } from '../types/common.types';
+
+export const NAVIGATION_ITEMS: ReadonlyArray<NavigationItem> = [
+  { label: 'Accueil', path: '/' },
+  { label: 'À propos', path: '/about' },
+  { label: 'Portfolio', path: '/portfolio' },
+  { label: 'Blog', path: '/blog' },
+  { label: 'Contact', path: '/contact' }
+] as const;

--- a/src/app/data/social-links.data.ts
+++ b/src/app/data/social-links.data.ts
@@ -1,0 +1,24 @@
+import { SocialLink } from '../types/common.types';
+
+export const SOCIAL_LINKS: ReadonlyArray<SocialLink> = [
+  {
+    platform: 'GitHub',
+    url: 'https://github.com/thierno-bah',
+    icon: '🐙'
+  },
+  {
+    platform: 'LinkedIn',
+    url: 'https://linkedin.com/in/thierno-bah',
+    icon: '💼'
+  },
+  {
+    platform: 'Twitter',
+    url: 'https://twitter.com/thierno_bah',
+    icon: '🐦'
+  },
+  {
+    platform: 'Email',
+    url: 'mailto:contact@thierno-bah.fr',
+    icon: '📧'
+  }
+] as const;

--- a/src/app/pages/about/about.component.html
+++ b/src/app/pages/about/about.component.html
@@ -1,0 +1,10 @@
+<section class="page">
+  <div class="container">
+    <h1 class="page-title">À propos</h1>
+    <p class="page-lead">
+      Passionné par le développement web, je conçois des expériences numériques
+      modernes avec une attention particulière à l'accessibilité, la performance
+      et la qualité du code.
+    </p>
+  </div>
+</section>

--- a/src/app/pages/about/about.component.scss
+++ b/src/app/pages/about/about.component.scss
@@ -1,0 +1,16 @@
+.page {
+  padding: 4rem 0;
+}
+
+.page-title {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 700;
+  color: var(--text-color);
+  margin-bottom: 1.5rem;
+}
+
+.page-lead {
+  font-size: 1.1rem;
+  color: var(--secondary-color);
+  max-width: 48ch;
+}

--- a/src/app/pages/about/about.component.ts
+++ b/src/app/pages/about/about.component.ts
@@ -1,0 +1,11 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-about',
+  imports: [CommonModule],
+  templateUrl: './about.component.html',
+  styleUrls: ['./about.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class AboutComponent {}

--- a/src/app/pages/blog/blog.component.html
+++ b/src/app/pages/blog/blog.component.html
@@ -1,0 +1,9 @@
+<section class="page">
+  <div class="container">
+    <h1 class="page-title">Blog</h1>
+    <p class="page-lead">
+      Articles techniques, retours d'expérience et veille autour de l'écosystème
+      JavaScript, du cloud et des bonnes pratiques d'ingénierie.
+    </p>
+  </div>
+</section>

--- a/src/app/pages/blog/blog.component.scss
+++ b/src/app/pages/blog/blog.component.scss
@@ -1,0 +1,16 @@
+.page {
+  padding: 4rem 0;
+}
+
+.page-title {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 700;
+  color: var(--text-color);
+  margin-bottom: 1.5rem;
+}
+
+.page-lead {
+  font-size: 1.1rem;
+  color: var(--secondary-color);
+  max-width: 48ch;
+}

--- a/src/app/pages/blog/blog.component.ts
+++ b/src/app/pages/blog/blog.component.ts
@@ -1,0 +1,11 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-blog',
+  imports: [CommonModule],
+  templateUrl: './blog.component.html',
+  styleUrls: ['./blog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class BlogComponent {}

--- a/src/app/pages/contact/contact.component.html
+++ b/src/app/pages/contact/contact.component.html
@@ -1,0 +1,9 @@
+<section class="page">
+  <div class="container">
+    <h1 class="page-title">Contact</h1>
+    <p class="page-lead">
+      Parlons de vos ambitions digitales&nbsp;! Envoyez-moi un message et je vous
+      répondrai rapidement pour imaginer la meilleure solution ensemble.
+    </p>
+  </div>
+</section>

--- a/src/app/pages/contact/contact.component.scss
+++ b/src/app/pages/contact/contact.component.scss
@@ -1,0 +1,16 @@
+.page {
+  padding: 4rem 0;
+}
+
+.page-title {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 700;
+  color: var(--text-color);
+  margin-bottom: 1.5rem;
+}
+
+.page-lead {
+  font-size: 1.1rem;
+  color: var(--secondary-color);
+  max-width: 48ch;
+}

--- a/src/app/pages/contact/contact.component.ts
+++ b/src/app/pages/contact/contact.component.ts
@@ -1,0 +1,11 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-contact',
+  imports: [CommonModule],
+  templateUrl: './contact.component.html',
+  styleUrls: ['./contact.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ContactComponent {}

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -24,9 +24,14 @@
         </div>
       </div>
       <div class="hero-image">
-        <div class="image-placeholder">
-          <span class="emoji">👨‍💻</span>
-        </div>
+        <img
+          ngSrc="assets/profile-placeholder.svg"
+          alt="Illustration de Thierno Bah"
+          width="320"
+          height="320"
+          priority
+          class="hero-portrait"
+        />
       </div>
     </div>
   </div>
@@ -36,11 +41,27 @@
   <div class="container">
     <h3 class="section-title">Ce que je fais</h3>
     <div class="features-grid">
-      <div class="feature-card" *ngFor="let feature of features">
-        <div class="feature-icon">{{ feature.icon }}</div>
-        <h4 class="feature-title">{{ feature.title }}</h4>
-        <p class="feature-description">{{ feature.description }}</p>
-      </div>
+      @for (feature of features(); track feature.title) {
+        <div class="feature-card">
+          <div class="feature-icon">{{ feature.icon }}</div>
+          <h4 class="feature-title">{{ feature.title }}</h4>
+          <p class="feature-description">{{ feature.description }}</p>
+        </div>
+      }
     </div>
+  </div>
+</section>
+
+<section class="cta-wrapper">
+  <div class="container">
+    <app-call-to-action
+      [title]="'Prêt à construire votre prochain projet ?'"
+      [description]="'Discutons de vos idées et donnons vie à une expérience digitale mémorable.'"
+      [primaryLabel]="'Parler de votre projet'"
+      [primaryLink]="'/contact'"
+      [secondaryLabel]="'Voir le portfolio'"
+      [secondaryLink]="'/portfolio'"
+      [emphasize]="true"
+    ></app-call-to-action>
   </div>
 </section>

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -1,10 +1,9 @@
-// Variables locales
 $hero-bg: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
 $card-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 $card-shadow-hover: 0 10px 25px rgba(0, 0, 0, 0.15);
 
 .hero {
-  padding: 4rem 0;
+  padding: 4rem 0 3rem;
   background: $hero-bg;
   min-height: 70vh;
   display: flex;
@@ -13,15 +12,15 @@ $card-shadow-hover: 0 10px 25px rgba(0, 0, 0, 0.15);
 
 .hero-content {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 4rem;
   align-items: center;
 }
 
 .hero-title {
-  font-size: 3rem;
+  font-size: clamp(2.5rem, 4vw, 3.25rem);
   font-weight: 700;
-  line-height: 1.2;
+  line-height: 1.1;
   margin-bottom: 1rem;
   color: var(--text-color);
 }
@@ -34,7 +33,7 @@ $card-shadow-hover: 0 10px 25px rgba(0, 0, 0, 0.15);
 }
 
 .hero-subtitle {
-  font-size: 1.5rem;
+  font-size: clamp(1.4rem, 2vw, 1.8rem);
   color: var(--secondary-color);
   font-weight: 400;
   margin-bottom: 1.5rem;
@@ -50,6 +49,7 @@ $card-shadow-hover: 0 10px 25px rgba(0, 0, 0, 0.15);
 .hero-actions {
   display: flex;
   gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .hero-image {
@@ -58,34 +58,16 @@ $card-shadow-hover: 0 10px 25px rgba(0, 0, 0, 0.15);
   align-items: center;
 }
 
-.image-placeholder {
-  width: 300px;
-  height: 300px;
-  background: linear-gradient(135deg, var(--primary-color), #7c3aed);
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 20px 40px rgba(37, 99, 235, 0.3);
-  animation: float 6s ease-in-out infinite;
-}
-
-.emoji {
-  font-size: 4rem;
-}
-
-@keyframes float {
-  0%, 100% {
-    transform: translateY(0px);
-  }
-  50% {
-    transform: translateY(-20px);
-  }
+.hero-portrait {
+  border-radius: 1.5rem;
+  box-shadow: 0 25px 45px rgba(37, 99, 235, 0.15);
+  object-fit: cover;
+  max-width: 100%;
 }
 
 .features {
-  padding: 5rem 0;
-  background-color: white;
+  padding: 5rem 0 4rem;
+  background-color: var(--surface-color);
 }
 
 .section-title {
@@ -103,14 +85,14 @@ $card-shadow-hover: 0 10px 25px rgba(0, 0, 0, 0.15);
 }
 
 .feature-card {
-  background: white;
+  background: var(--background-color);
   padding: 2rem;
   border-radius: 1rem;
   text-align: center;
   box-shadow: $card-shadow;
   border: 1px solid var(--border-color);
-  transition: all 0.3s ease;
-  
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+
   &:hover {
     transform: translateY(-5px);
     box-shadow: $card-shadow-hover;
@@ -134,26 +116,35 @@ $card-shadow-hover: 0 10px 25px rgba(0, 0, 0, 0.15);
   line-height: 1.6;
 }
 
-/* Responsive */
+.cta-wrapper {
+  padding: 4rem 0 6rem;
+  background: linear-gradient(180deg, transparent, rgba(37, 99, 235, 0.1));
+}
+
+@media (max-width: 1024px) {
+  .hero-content {
+    gap: 3rem;
+  }
+}
+
 @media (max-width: 768px) {
+  .hero {
+    padding: 3rem 0 2rem;
+    min-height: auto;
+  }
+
   .hero-content {
     grid-template-columns: 1fr;
     text-align: center;
-    gap: 2rem;
-  }
-
-  .hero-title {
-    font-size: 2.5rem;
+    gap: 2.5rem;
   }
 
   .hero-actions {
     justify-content: center;
-    flex-wrap: wrap;
   }
 
-  .image-placeholder {
-    width: 250px;
-    height: 250px;
+  .features {
+    padding: 4rem 0 3rem;
   }
 
   .features-grid {

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -1,35 +1,17 @@
-import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { RouterModule } from '@angular/router';
+import { FEATURES } from '../../data/features.data';
+import { Feature } from '../../types/common.types';
+import { CallToActionComponent } from '../../components/call-to-action/call-to-action.component';
 
 @Component({
   selector: 'app-home',
-  standalone: true,
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, CallToActionComponent, NgOptimizedImage],
   templateUrl: './home.component.html',
-  styleUrls: ['./home.component.scss']
+  styleUrls: ['./home.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class HomeComponent {
-  features = [
-    {
-      icon: '🎨',
-      title: 'Frontend Development',
-      description: 'Création d\'interfaces utilisateur modernes avec React, Angular et Vue.js'
-    },
-    {
-      icon: '⚙️',
-      title: 'Backend Development',
-      description: 'APIs robustes avec Node.js, Python et bases de données relationnelles/NoSQL'
-    },
-    {
-      icon: '🚀',
-      title: 'DevOps & Cloud',
-      description: 'Déploiement et infrastructure cloud avec AWS, Docker et CI/CD'
-    },
-    {
-      icon: '📱',
-      title: 'Mobile Development',
-      description: 'Applications mobiles cross-platform avec React Native et Flutter'
-    }
-  ];
+  protected readonly features = signal<ReadonlyArray<Feature>>(FEATURES);
 }

--- a/src/app/pages/portfolio/portfolio.component.html
+++ b/src/app/pages/portfolio/portfolio.component.html
@@ -1,0 +1,9 @@
+<section class="page">
+  <div class="container">
+    <h1 class="page-title">Portfolio</h1>
+    <p class="page-lead">
+      Découvrez une sélection de projets mettant en avant des interfaces soignées,
+      des architectures scalables et des expériences utilisateurs immersives.
+    </p>
+  </div>
+</section>

--- a/src/app/pages/portfolio/portfolio.component.scss
+++ b/src/app/pages/portfolio/portfolio.component.scss
@@ -1,0 +1,16 @@
+.page {
+  padding: 4rem 0;
+}
+
+.page-title {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 700;
+  color: var(--text-color);
+  margin-bottom: 1.5rem;
+}
+
+.page-lead {
+  font-size: 1.1rem;
+  color: var(--secondary-color);
+  max-width: 48ch;
+}

--- a/src/app/pages/portfolio/portfolio.component.ts
+++ b/src/app/pages/portfolio/portfolio.component.ts
@@ -1,0 +1,11 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-portfolio',
+  imports: [CommonModule],
+  templateUrl: './portfolio.component.html',
+  styleUrls: ['./portfolio.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PortfolioComponent {}

--- a/src/app/services/theme.service.ts
+++ b/src/app/services/theme.service.ts
@@ -1,0 +1,34 @@
+import { Injectable, effect, inject, signal } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+
+type Theme = 'light' | 'dark';
+
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  private readonly document = inject(DOCUMENT);
+  private readonly mediaQuery = typeof window !== 'undefined'
+    ? window.matchMedia('(prefers-color-scheme: dark)')
+    : undefined;
+
+  readonly currentTheme = signal<Theme>(this.mediaQuery?.matches ? 'dark' : 'light');
+
+  constructor() {
+    effect(() => {
+      const theme = this.currentTheme();
+      const rootElement = this.document.documentElement;
+      rootElement.setAttribute('data-theme', theme);
+    });
+
+    this.mediaQuery?.addEventListener('change', event => {
+      this.currentTheme.set(event.matches ? 'dark' : 'light');
+    });
+  }
+
+  toggle(): void {
+    this.currentTheme.update(theme => (theme === 'light' ? 'dark' : 'light'));
+  }
+
+  setTheme(theme: Theme): void {
+    this.currentTheme.set(theme);
+  }
+}

--- a/src/app/types/common.types.ts
+++ b/src/app/types/common.types.ts
@@ -10,6 +10,12 @@ export interface SocialLink {
   icon: string;
 }
 
+export interface Feature {
+  icon: string;
+  title: string;
+  description: string;
+}
+
 export interface Project {
   id: string;
   title: string;

--- a/src/assets/profile-placeholder.svg
+++ b/src/assets/profile-placeholder.svg
@@ -1,0 +1,22 @@
+<svg width="320" height="320" viewBox="0 0 320 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2563EB" />
+      <stop offset="100%" stop-color="#7C3AED" />
+    </linearGradient>
+    <clipPath id="clip">
+      <circle cx="160" cy="160" r="150" />
+    </clipPath>
+  </defs>
+  <rect width="320" height="320" rx="48" fill="url(#gradient)" />
+  <g clip-path="url(#clip)">
+    <circle cx="160" cy="130" r="70" fill="rgba(255, 255, 255, 0.18)" />
+    <path
+      d="M160 220C110 220 70 260 70 310H250C250 260 210 220 160 220Z"
+      fill="rgba(255, 255, 255, 0.18)"
+    />
+  </g>
+  <text x="50%" y="92%" text-anchor="middle" font-size="28" fill="rgba(255,255,255,0.85)" font-family="'Inter', sans-serif">
+    Thierno Bah
+  </text>
+</svg>

--- a/src/global_styles.scss
+++ b/src/global_styles.scss
@@ -4,9 +4,11 @@
 $primary-color: #2563eb;
 $secondary-color: #64748b;
 $background-color: #ffffff;
+$surface-color: #f8fafc;
 $text-color: #1e293b;
 $border-color: #e2e8f0;
 $shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+$shadow-soft: 0 10px 25px rgba(15, 23, 42, 0.05);
 
 // Breakpoints
 $mobile: 768px;
@@ -23,18 +25,34 @@ $desktop: 1200px;
   --primary-color: #{$primary-color};
   --secondary-color: #{$secondary-color};
   --background-color: #{$background-color};
+  --surface-color: #{$surface-color};
   --text-color: #{$text-color};
   --border-color: #{$border-color};
   --shadow: #{$shadow};
+  --shadow-soft: #{$shadow-soft};
+  --surface-hover: rgba(15, 23, 42, 0.05);
+}
+
+:root[data-theme='dark'] {
+  --primary-color: #60a5fa;
+  --secondary-color: #cbd5f5;
+  --background-color: #0f172a;
+  --surface-color: #111c34;
+  --text-color: #e2e8f0;
+  --border-color: rgba(148, 163, 184, 0.4);
+  --shadow: 0 1px 3px 0 rgba(15, 23, 42, 0.4);
+  --shadow-soft: 0 10px 30px rgba(15, 23, 42, 0.45);
+  --surface-hover: rgba(148, 163, 184, 0.15);
 }
 
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   line-height: 1.6;
-  color: $text-color;
-  background-color: $background-color;
+  color: var(--text-color);
+  background-color: var(--background-color);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 .container {
@@ -57,24 +75,24 @@ body {
 }
 
 .btn-primary {
-  background-color: $primary-color;
-  color: white;
-  
+  background-color: var(--primary-color);
+  color: #fff;
+
   &:hover {
-    background-color: #1d4ed8;
+    background-color: color-mix(in srgb, var(--primary-color) 85%, #000 15%);
     transform: translateY(-1px);
-    box-shadow: 0 4px 8px rgba(37, 99, 235, 0.3);
+    box-shadow: 0 4px 8px color-mix(in srgb, var(--primary-color) 45%, transparent);
   }
 }
 
 .btn-outline {
   background-color: transparent;
-  color: $primary-color;
-  border: 2px solid $primary-color;
+  color: var(--primary-color);
+  border: 2px solid var(--primary-color);
 
   &:hover {
-    background-color: $primary-color;
-    color: white;
+    background-color: color-mix(in srgb, var(--primary-color) 15%, transparent);
+    color: #fff;
   }
 }
 
@@ -92,6 +110,17 @@ body {
 
 .fade-in {
   animation: fadeIn 0.6s ease-out;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }
 
 /* Responsive */

--- a/src/index.html
+++ b/src/index.html
@@ -14,6 +14,13 @@
     <meta property="og:description" content="Portfolio et blog d'un développeur passionné" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.thierno-bah.fr/" />
+    <meta property="og:image" content="/assets/profile-placeholder.svg" />
+    <meta property="og:locale" content="fr_FR" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Thierno Bah - Développeur Full Stack" />
+    <meta name="twitter:description" content="Portfolio et blog d'un développeur passionné" />
+    <meta name="twitter:image" content="/assets/profile-placeholder.svg" />
+    <meta name="theme-color" content="#2563eb" />
     
     <!-- Preconnect pour optimiser les performances -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,29 +1,47 @@
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideRouter } from '@angular/router';
-import { Component } from '@angular/core';
+import { provideRouter, Routes, withInMemoryScrolling } from '@angular/router';
+import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { LayoutComponent } from './app/components/layout/layout.component';
-import { HomeComponent } from './app/pages/home/home.component';
 
-// Routes de base
-const routes = [
-  { path: '', component: HomeComponent },
-  { path: 'about', component: HomeComponent }, // Temporaire
-  { path: 'portfolio', component: HomeComponent }, // Temporaire
-  { path: 'blog', component: HomeComponent }, // Temporaire  
-  { path: 'contact', component: HomeComponent }, // Temporaire
+const routes: Routes = [
+  {
+    path: '',
+    loadComponent: () => import('./app/pages/home/home.component').then(m => m.HomeComponent),
+    title: 'Accueil — Thierno Bah'
+  },
+  {
+    path: 'about',
+    loadComponent: () => import('./app/pages/about/about.component').then(m => m.AboutComponent),
+    title: 'À propos — Thierno Bah'
+  },
+  {
+    path: 'portfolio',
+    loadComponent: () => import('./app/pages/portfolio/portfolio.component').then(m => m.PortfolioComponent),
+    title: 'Portfolio — Thierno Bah'
+  },
+  {
+    path: 'blog',
+    loadComponent: () => import('./app/pages/blog/blog.component').then(m => m.BlogComponent),
+    title: 'Blog — Thierno Bah'
+  },
+  {
+    path: 'contact',
+    loadComponent: () => import('./app/pages/contact/contact.component').then(m => m.ContactComponent),
+    title: 'Contact — Thierno Bah'
+  },
   { path: '**', redirectTo: '' }
 ];
 
 @Component({
   selector: 'app-root',
-  standalone: true,
   imports: [LayoutComponent],
-  template: '<app-layout></app-layout>'
+  template: '<app-layout></app-layout>',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class App {}
 
 bootstrapApplication(App, {
   providers: [
-    provideRouter(routes)
+    provideRouter(routes, withInMemoryScrolling({ scrollPositionRestoration: 'enabled' }))
   ]
 });


### PR DESCRIPTION
## Summary
- adopt signal-based header and footer with theme toggle, accessible menu, and centralized data providers
- refresh home page with NgOptimizedImage hero, reusable call-to-action component, and updated styling
- introduce lazy-loaded content pages, SEO metadata, theme service, and asset pipeline updates

## Testing
- npm run build *(fails: unable to inline external Google Fonts due to 403 response in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e036945a7c83328a8430c320407c5d